### PR TITLE
Fix defect: network activity indicator is invisible when data is loading

### DIFF
--- a/ClassicPhotos/ListViewController.swift
+++ b/ClassicPhotos/ListViewController.swift
@@ -231,6 +231,8 @@ class ListViewController: UITableViewController {
             }
 
             self.tableView.reloadData()
+                                                                        
+            UIApplication.shared.isNetworkActivityIndicatorVisible = false
         }
         
         
@@ -241,6 +243,6 @@ class ListViewController: UITableViewController {
         
 
         
-        UIApplication.shared.isNetworkActivityIndicatorVisible = false
+        
     }
 }


### PR DESCRIPTION
Moved UIApplication.shared.isNetworkActivityIndicatorVisible = false inside closure of URLSessionDataTask. Therefore, the network activity indicator becomes invisible after photo details are downloaded.